### PR TITLE
chore: ignore pylint directory

### DIFF
--- a/{{cookiecutter.project_name}}/.gitignore
+++ b/{{cookiecutter.project_name}}/.gitignore
@@ -135,3 +135,4 @@ dmypy.json
 
 # reports
 pylint.html
+.pylint.d


### PR DESCRIPTION
During linting pylint created a `.pylint.d` directory. It would be nice to git-ignore it by default.

![Screenshot 2021-12-06 at 11 27 39](https://user-images.githubusercontent.com/51201318/144831201-bd8fade6-b01a-4c53-bc63-3d95329e1448.png)
