### PR TITLE
fix: incorporate small fixes from latest project setup

### DIFF
--- a/{{cookiecutter.project_name}}/.github/workflows/lint_and_docs.yaml
+++ b/{{cookiecutter.project_name}}/.github/workflows/lint_and_docs.yaml
@@ -11,10 +11,10 @@ jobs:
     steps:
       - name: Cancel previous run
         uses: styfle/cancel-workflow-action@0.11.0
-      {% raw -%}
+        {% raw -%}
         with:
           access_token: ${{ github.token }}
-      {%- endraw %}
+        {%- endraw %}
       - uses: actions/checkout@v3
       - name: Set up Python
         uses: actions/setup-python@v4

--- a/{{cookiecutter.project_name}}/.github/workflows/lint_and_docs.yaml
+++ b/{{cookiecutter.project_name}}/.github/workflows/lint_and_docs.yaml
@@ -8,6 +8,8 @@ jobs:
     permissions:
       id-token: write
       pages: write
+      actions: write
+      contents: read
     steps:
       - name: Cancel previous run
         uses: styfle/cancel-workflow-action@0.11.0

--- a/{{cookiecutter.project_name}}/docs/_config.yml
+++ b/{{cookiecutter.project_name}}/docs/_config.yml
@@ -105,7 +105,7 @@ sphinx:
     suppress_warnings: ["mystnb.unknown_mime_type"]  # needed for plotly rendering
     autodoc_show_sourcelink: True
     add_module_names: False
-    github_username: {{cookiecutter.author}}}
+    github_username: {{cookiecutter.author}}
     github_repository: {{cookiecutter.project_name}}
     python_use_unqualified_type_names: True
     nb_mime_priority_overrides: [


### PR DESCRIPTION
This PR includes some small fixes that have been noticed while setting up a project with pymetrius.

Besides these, I also noticed that sphinx-spelling does not work any longer, because `ImportError: The 'enchant' C library was not found and maybe needs to be installed` (See: https://github.com/pyenchant/pyenchant/issues/316). I saw that there is an open issue regarding [sphinx -> mkdocs](https://github.com/appliedAI-Initiative/pymetrius/issues/8) so I did not incorporate this already.