### PR TITLE
Disable ruff rule COM812, which causes undesirable reformats

### DIFF
--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -86,6 +86,7 @@ select = [
     "ASYNC", "B", "C4", "C90", "COM", "D", "DTZ", "E", "F", "FLY", "G", "I", "ISC", "PIE", "PLC", "PLE", "PLW", "RET", "RUF", "RSE", "SIM", "TID", "UP", "W", "YTT",
 ]
 ignore = [
+    "COM812",  # requires trailing commas and can cause undesirable reformats when calling `poe format` multiple times (see https://github.com/appliedAI-Initiative/pymetrius/issues/17)
     "E501", # line too long. black does a good enough job
     "E741", # variable names like "l". this isn't a huge problem
     "B008", # do not perform function calls in argument defaults. we do this sometimes


### PR DESCRIPTION
Calling `poe format` once does not suffice when this rule is enabled

Fixes #17